### PR TITLE
Using OperatorNameOnLicence in preference for agency_name

### DIFF
--- a/src/gtfs/AgencyStream.ts
+++ b/src/gtfs/AgencyStream.ts
@@ -12,8 +12,9 @@ export class AgencyStream extends GTFSFileStream<TransXChange> {
     for (const operatorId of Object.keys(data.Operators)) {
       if (!this.agenciesSeen[operatorId]) {
         const operator = data.Operators[operatorId];
+        const agencyName = operator.OperatorNameOnLicence || operator.OperatorShortName;
 
-        this.pushLine(`${operatorId},${operator.OperatorShortName},http://agency.com,Europe/London,en,,`);
+        this.pushLine(`${operatorId},${agencyName},http://agency.com,Europe/London,en,,`);
 
         this.agenciesSeen[operatorId] = true;
       }


### PR DESCRIPTION
I noticed a bunch of the `agency_name` values were truncated in the agency.txt file.  It seems the `OperatorShortName` is normally the `OperatorNameOnLicence` truncated:
 
```xml
set_6-230-A-y08-1.xml
3314:      <OperatorShortName>Autocar Bus &amp; Coach Ser</OperatorShortName>
3315:      <OperatorNameOnLicence>Autocar Bus &amp; Coach Services</OperatorNameOnLicence>
```
I have changed the code to use `OperatorNameOnLicence` in prefence for the `agency_name`.  `OperatorNameOnLicence` is allowed to be `undefined` so the logic still falls back to `OperatorShortName`.