### PR TITLE
Remove hardcoded limit on heap

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Or using zip files:
 transxchange2gtfs multiple-transxchange-files.zip /path/*.zip single-transxchange.xml gtfs-output.zip
 ```
 
+On occasion, a large dataset will cause a `heap out of memory issue`. In this case, set the `NODE_OPTIONS` environment variable to increase the heap size.
+For example to set to 8GiB, in a linux shell:
+
+```
+NODE_OPTIONS=--max-old-space-size=8192 transxchange2gtfs transxchange.zip gtfs-output.zip
+```
+
 ## Notes
 
 - All stop times are left in the original timezones (assumed to be local time).

--- a/bin/transxchange2gtfs.sh
+++ b/bin/transxchange2gtfs.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-":" //# comment; exec /usr/bin/env node --max_old_space_size=4000 "$0" "$@"
+":" //# comment; exec /usr/bin/env node "$0" "$@"
 require("../dist/src/cli.js");


### PR DESCRIPTION
Some runs exceed the 4000KiB limit specified. This commit removes the
statement of `max_old_space_size` in favour of users being able to
explicitly set the heap size via NODE_OPTIONS.

Have also added documentation to this end.

Should probably also bump version to 1.5.1.