### PR TITLE
Also include <LicensedOperator>s

### DIFF
--- a/src/transxchange/TransXChangeStream.ts
+++ b/src/transxchange/TransXChangeStream.ts
@@ -42,7 +42,7 @@ export class TransXChangeStream extends Transform {
     const result: TransXChange = {
       StopPoints: stops,
       JourneySections: tx.JourneyPatternSections[0].JourneyPatternSection.reduce(this.getJourneySections, {}),
-      Operators: tx.Operators[0].Operator.reduce(this.getOperators, {}),
+      Operators: (tx.Operators[0].Operator || []).concat(tx.Operators[0].LicensedOperator || []).reduce(this.getOperators, {}),
       Services: services,
       VehicleJourneys: tx.VehicleJourneys[0].VehicleJourney
         .map((v: any) => this.getVehicleJourney(v, patternIndex, services))
@@ -104,7 +104,7 @@ export class TransXChangeStream extends Transform {
     index[operator.$.id] = {
       OperatorCode: operator.OperatorCode[0],
       OperatorShortName: operator.OperatorShortName[0],
-      OperatorNameOnLicence: operator.OperatorNameOnLicence && operator.OperatorNameOnLicence[0],
+      OperatorNameOnLicence: operator.OperatorNameOnLicence && (operator.OperatorNameOnLicence[0]._ || operator.OperatorNameOnLicence[0]),
     };
 
     return index;


### PR DESCRIPTION
From the spec

> A Service has a RegisteredOperator, and may have additional AssociatedOperator
> instances. Operators may be instances of either LicensedOperator or Operator.

So I added those.

The 2nd change in here relates to attributes on xml elements. `xml2js` has some bizarre quirks: if an xml element has any attributes, the text is embedded in the `_` property. So, for example:

```xml
      <OperatorNameOnLicence xml:lang="en">First Manchester Limited</OperatorNameOnLicence>
```

breaks on the existing code. I don't really love this solution, because it only fixes the bug for `OperatorNameOnLicence`, but fixing it everywhere would mean either replacing the xml library.

Let me know if I should add tests.