### PR TITLE
[Fix] Processing failure when certain [0] index fields not present

### DIFF
--- a/src/transxchange/TransXChangeStream.ts
+++ b/src/transxchange/TransXChangeStream.ts
@@ -94,8 +94,8 @@ export class TransXChangeStream extends Transform {
   private getJourneyStop(stop: any): JourneyStop {
     return {
       Activity: stop.Activity ? stop.Activity[0] : StopActivity.PickUpAndSetDown,
-      StopPointRef: stop.StopPointRef[0],
-      TimingStatus: stop.TimingStatus[0],
+      StopPointRef: stop.StopPointRef?.[0] ?? '',
+      TimingStatus: stop.TimingStatus?.[0] ?? '',
       WaitTime: stop.WaitTime && Duration.parse(stop.WaitTime[0])
     };
   }

--- a/src/transxchange/TransXChangeStream.ts
+++ b/src/transxchange/TransXChangeStream.ts
@@ -10,20 +10,20 @@ import {
   Operators,
   Services,
   StopActivity,
-  StopPoint,
-  TimingLink,
+  StopPoint, TimingLink,
   TransXChange,
-  VehicleJourney,
+  VehicleJourney
 } from "./TransXChange";
-import { Transform, TransformCallback } from "stream";
+import {Transform, TransformCallback} from "stream";
 import autobind from "autobind-decorator";
-import { Duration, LocalDate, LocalTime } from "js-joda";
+import {Duration, LocalDate, LocalTime} from "js-joda";
 
 /**
  * Transforms JSON objects into a TransXChange objects
  */
 @autobind
 export class TransXChangeStream extends Transform {
+
   constructor() {
     super({ objectMode: true });
   }
@@ -31,36 +31,21 @@ export class TransXChangeStream extends Transform {
   /**
    * Extract the stops, journeys and operators and emit them as a TransXChange object
    */
-  public _transform(
-    data: any,
-    encoding: string,
-    callback: TransformCallback
-  ): void {
+  public _transform(data: any, encoding: string, callback: TransformCallback): void {
     const tx = data.TransXChange;
-    const patternIndex = tx.VehicleJourneys[0].VehicleJourney.reduce(
-      this.getJourneyPatternIndex,
-      {}
-    );
+    const patternIndex = tx.VehicleJourneys[0].VehicleJourney.reduce(this.getJourneyPatternIndex, {});
     const services = tx.Services[0].Service.reduce(this.getServices, {});
     const stops = tx.StopPoints[0].AnnotatedStopPointRef
-      ? tx.StopPoints[0].AnnotatedStopPointRef.map(
-          this.getStopFromAnnotatedStopPointRef
-        )
-      : tx.StopPoints[0].StopPoint.map(this.getStopFromStopPoint);
+        ? tx.StopPoints[0].AnnotatedStopPointRef.map(this.getStopFromAnnotatedStopPointRef)
+        : tx.StopPoints[0].StopPoint.map(this.getStopFromStopPoint);
 
     const result: TransXChange = {
       StopPoints: stops,
-      JourneySections: tx.JourneyPatternSections?.[0]?.JourneyPatternSection.reduce(
-        this.getJourneySections,
-        {}
-      ),
-      Operators: (tx.Operators?.[0]?.Operator || [])
-        .concat(tx.Operators?.[0]?.LicensedOperator || [])
-        .reduce(this.getOperators, {}),
+      JourneySections: tx.JourneyPatternSections[0].JourneyPatternSection.reduce(this.getJourneySections, {}),
+      Operators: (tx.Operators[0].Operator || []).concat(tx.Operators[0].LicensedOperator || []).reduce(this.getOperators, {}),
       Services: services,
-      VehicleJourneys: (
-        tx.VehicleJourneys?.[0]?.VehicleJourney ?? []
-      ).map((v: any) => this.getVehicleJourney(v, patternIndex, services)),
+      VehicleJourneys: tx.VehicleJourneys[0].VehicleJourney
+        .map((v: any) => this.getVehicleJourney(v, patternIndex, services))
     };
 
     callback(undefined, result);
@@ -68,78 +53,58 @@ export class TransXChangeStream extends Transform {
 
   private getStopFromAnnotatedStopPointRef(stop: any): StopPoint {
     return {
-      StopPointRef: stop.StopPointRef?.[0] ?? "",
-      CommonName: stop.CommonName?.[0] ?? "",
-      LocalityName: stop.LocalityName?.[0] ? stop.LocalityName[0] : "",
-      LocalityQualifier: stop.LocalityQualifier?.[0]
-        ? stop.LocalityQualifier[0]
-        : "",
-      Location: {
-        Latitude:
-          stop.Location?.[0] && stop.Location[0].Latitude
-            ? Number(stop.Location[0].Latitude[0])
-            : 0.0,
-        Longitude:
-          stop.Location?.[0] && stop.Location[0].Longitude
-            ? Number(stop.Location[0].Longitude[0])
-            : 0.0,
-      },
+      StopPointRef: stop?.StopPointRef?.[0] ?? "",
+      CommonName: stop?.CommonName?.[0] ?? "",
+      LocalityName: stop?.LocalityName?.[0] ? stop.LocalityName[0] : "",
+      LocalityQualifier: stop?.LocalityQualifier?.[0] ? stop.LocalityQualifier[0] : "",
+      Location:  {
+        Latitude: stop?.Location?.[0]?.Latitude ? Number(stop.Location[0].Latitude[0]) : 0.0,
+        Longitude: stop?.Location?.[0]?.Longitude ? Number(stop.Location[0].Longitude[0]) : 0.0
+      }
     };
   }
 
   private getStopFromStopPoint(stop: any): StopPoint {
     return {
-      StopPointRef: stop.AtcoCode?.[0] ?? "",
-      CommonName: stop.Descriptor?.[0]?.CommonName?.[0],
+      StopPointRef: stop?.AtcoCode?.[0] ?? "",
+      CommonName: stop?.Descriptor?.[0]?.CommonName?.[0] ?? "",
       LocalityName: "",
       LocalityQualifier: "",
-      Location: {
+      Location:  {
         Latitude: 0.0,
-        Longitude: 0.0,
-      },
+        Longitude: 0.0
+      }
     };
   }
 
-  private getJourneySections(
-    index: JourneyPatternSections,
-    section: any
-  ): JourneyPatternSections {
-    index[section.$.id] = section.JourneyPatternTimingLink
-      ? section.JourneyPatternTimingLink.map(this.getLink)
-      : [];
+  private getJourneySections(index: JourneyPatternSections, section: any): JourneyPatternSections {
+    index[section.$.id] = section.JourneyPatternTimingLink ? section.JourneyPatternTimingLink.map(this.getLink) : [];
 
     return index;
   }
 
   private getLink(l: any): TimingLink {
     return {
-      From: this.getJourneyStop(l.From?.[0] ?? ""),
-      To: this.getJourneyStop(l.To?.[0] ?? ""),
-      RunTime: Duration.parse(l.RunTime?.[0] ?? ""),
+      From: this.getJourneyStop(l?.From?.[0] ?? ""),
+      To: this.getJourneyStop(l?.To?.[0] ?? ""),
+      RunTime: Duration.parse(l?.RunTime?.[0] ?? "")
     };
   }
 
   private getJourneyStop(stop: any): JourneyStop {
     return {
-      Activity: stop.Activity?.[0]
-        ? stop.Activity[0]
-        : StopActivity.PickUpAndSetDown,
-      StopPointRef: stop.StopPointRef?.[0] ?? "",
-      TimingStatus: stop.TimingStatus?.[0] ?? "",
-      WaitTime: stop.WaitTime && Duration.parse(stop.WaitTime[0]),
+      Activity: stop?.Activity?.[0] ? stop.Activity[0] : StopActivity.PickUpAndSetDown,
+      StopPointRef: stop?.StopPointRef?.[0] ?? "",
+      TimingStatus: stop?.TimingStatus?.[0] ?? "",
+      WaitTime: stop?.WaitTime?.[0] && Duration.parse(stop.WaitTime[0])
     };
   }
 
   private getOperators(index: Operators, operator: any): Operators {
     index[operator.$.id] = {
-      OperatorCode: operator.OperatorCode?.[0]
-        ? operator.OperatorCode[0]
-        : operator.NationalOperatorCode[0],
-      OperatorShortName: operator.OperatorShortName[0],
-      OperatorNameOnLicence:
-        operator.OperatorNameOnLicence &&
-        (operator.OperatorNameOnLicence[0]._ ||
-          operator.OperatorNameOnLicence[0]),
+      OperatorCode: operator?.OperatorCode?.[0] ? operator.OperatorCode[0] : operator?.NationalOperatorCode?.[0] ?? "",
+      OperatorShortName: operator?.OperatorShortName?.[0] ?? "",
+      OperatorNameOnLicence: operator?.OperatorNameOnLicence?.[0] ? (operator.OperatorNameOnLicence[0]?._ ?? operator.OperatorNameOnLicence[0]) : "",
     };
 
     return index;
@@ -151,31 +116,23 @@ export class TransXChangeStream extends Transform {
       Lines: service.Lines[0].Line.reduce(this.getLines, {}),
       OperatingPeriod: this.getDateRange(service.OperatingPeriod[0]),
       RegisteredOperatorRef: service.RegisteredOperatorRef[0],
-      Description: service.Description
-        ? service.Description[0].replace(/[\r\n\t]/g, "")
-        : "",
+      Description: service.Description ? service.Description[0].replace(/[\r\n\t]/g, "") : "",
       Mode: service.Mode ? service.Mode[0] : Mode.Bus,
-      StandardService: service.StandardService[0].JourneyPattern.reduce(
-        this.getJourneyPattern,
-        {}
-      ),
+      StandardService: service.StandardService[0].JourneyPattern.reduce(this.getJourneyPattern, {}),
       ServiceOrigin: service.StandardService[0].Origin?.[0],
       ServiceDestination: service.StandardService[0].Destination?.[0],
       OperatingProfile: service.OperatingProfile
         ? this.getOperatingProfile(service.OperatingProfile[0])
-        : undefined,
+        : undefined
     };
 
     return index;
   }
 
-  private getJourneyPattern(
-    patterns: JourneyPatterns,
-    pattern: any
-  ): JourneyPatterns {
+  private getJourneyPattern(patterns: JourneyPatterns, pattern: any): JourneyPatterns {
     patterns[pattern.$.id] = {
       Direction: pattern.Direction[0],
-      Sections: pattern.JourneyPatternSectionRefs,
+      Sections: pattern.JourneyPatternSectionRefs
     };
 
     return patterns;
@@ -190,31 +147,21 @@ export class TransXChangeStream extends Transform {
   private getDateRange(dates: any): DateRange {
     return {
       StartDate: LocalDate.parse(dates.StartDate[0]),
-      EndDate:
-        dates.EndDate && dates.EndDate[0]
-          ? LocalDate.parse(dates.EndDate[0])
-          : LocalDate.parse("2099-12-31"),
+      EndDate: dates.EndDate && dates.EndDate[0] ? LocalDate.parse(dates.EndDate[0]) : LocalDate.parse("2099-12-31"),
     };
   }
 
-  private getVehicleJourney(
-    vehicle: any,
-    index: JourneyPatternIndex,
-    services: Services
-  ): VehicleJourney {
+  private getVehicleJourney(vehicle: any, index: JourneyPatternIndex, services: Services): VehicleJourney {
     return {
       LineRef: vehicle.LineRef[0],
       ServiceRef: vehicle.ServiceRef[0],
       VehicleJourneyCode: vehicle.VehicleJourneyCode[0],
-      JourneyPatternRef: vehicle.JourneyPatternRef
-        ? vehicle.JourneyPatternRef[0]
-        : index[vehicle.VehicleJourneyRef[0]],
+      JourneyPatternRef: vehicle.JourneyPatternRef ? vehicle.JourneyPatternRef[0] : index[vehicle.VehicleJourneyRef[0]],
       DepartureTime: LocalTime.parse(vehicle.DepartureTime[0]),
       OperatingProfile: vehicle.OperatingProfile
         ? this.getOperatingProfile(vehicle.OperatingProfile[0])
         : services[vehicle.ServiceRef[0]].OperatingProfile!,
-      OperationalBlockNumber:
-        vehicle.Operational?.[0]?.Block?.[0].BlockNumber?.[0],
+      OperationalBlockNumber: vehicle.Operational?.[0]?.Block?.[0].BlockNumber?.[0]
     };
   }
 
@@ -222,52 +169,28 @@ export class TransXChangeStream extends Transform {
     const result = {
       BankHolidayOperation: {
         DaysOfOperation: [],
-        DaysOfNonOperation: [],
+        DaysOfNonOperation: []
       },
       SpecialDaysOperation: {
         DaysOfOperation: [],
-        DaysOfNonOperation: [],
+        DaysOfNonOperation: []
       },
       RegularDayType: profile.RegularDayType[0].DaysOfWeek
         ? this.getDaysOfWeek(profile.RegularDayType[0].DaysOfWeek[0])
-        : ("HolidaysOnly" as "HolidaysOnly"),
+        : "HolidaysOnly" as "HolidaysOnly"
     };
 
-    if (
-      profile.BankHolidayOperation &&
-      profile.BankHolidayOperation[0].DaysOfOperation &&
-      profile.BankHolidayOperation[0].DaysOfOperation[0]
-    ) {
-      result.BankHolidayOperation.DaysOfOperation = profile.BankHolidayOperation[0].DaysOfOperation.map(
-        (bh: any) => Object.keys(bh)[0]
-      );
+    if (profile.BankHolidayOperation && profile.BankHolidayOperation[0].DaysOfOperation && profile.BankHolidayOperation[0].DaysOfOperation[0]) {
+      result.BankHolidayOperation.DaysOfOperation = profile.BankHolidayOperation[0].DaysOfOperation.map((bh: any) => Object.keys(bh)[0]);
     }
-    if (
-      profile.BankHolidayOperation &&
-      profile.BankHolidayOperation[0].DaysOfNonOperation &&
-      profile.BankHolidayOperation[0].DaysOfNonOperation[0]
-    ) {
-      result.BankHolidayOperation.DaysOfNonOperation = profile.BankHolidayOperation[0].DaysOfNonOperation.map(
-        (bh: any) => Object.keys(bh)[0]
-      );
+    if (profile.BankHolidayOperation && profile.BankHolidayOperation[0].DaysOfNonOperation && profile.BankHolidayOperation[0].DaysOfNonOperation[0]) {
+      result.BankHolidayOperation.DaysOfNonOperation = profile.BankHolidayOperation[0].DaysOfNonOperation.map((bh: any) => Object.keys(bh)[0]);
     }
-    if (
-      profile.SpecialDaysOperation &&
-      profile.SpecialDaysOperation[0].DaysOfOperation &&
-      profile.SpecialDaysOperation[0].DaysOfOperation[0]
-    ) {
-      result.SpecialDaysOperation.DaysOfOperation = profile.SpecialDaysOperation[0].DaysOfOperation[0].DateRange.map(
-        this.getDateRange
-      );
+    if (profile.SpecialDaysOperation && profile.SpecialDaysOperation[0].DaysOfOperation && profile.SpecialDaysOperation[0].DaysOfOperation[0]) {
+      result.SpecialDaysOperation.DaysOfOperation = profile.SpecialDaysOperation[0].DaysOfOperation[0].DateRange.map(this.getDateRange);
     }
-    if (
-      profile.SpecialDaysOperation &&
-      profile.SpecialDaysOperation[0].DaysOfNonOperation &&
-      profile.SpecialDaysOperation[0].DaysOfNonOperation[0]
-    ) {
-      result.SpecialDaysOperation.DaysOfNonOperation = profile.SpecialDaysOperation[0].DaysOfNonOperation[0].DateRange.map(
-        this.getDateRange
-      );
+    if (profile.SpecialDaysOperation && profile.SpecialDaysOperation[0].DaysOfNonOperation && profile.SpecialDaysOperation[0].DaysOfNonOperation[0]) {
+      result.SpecialDaysOperation.DaysOfNonOperation = profile.SpecialDaysOperation[0].DaysOfNonOperation[0].DateRange.map(this.getDateRange);
     }
 
     return result;
@@ -276,15 +199,10 @@ export class TransXChangeStream extends Transform {
   private getDaysOfWeek(days: any): DaysOfWeek[] {
     return Object.keys(days).length === 0
       ? [[0, 0, 0, 0, 0, 0, 0]]
-      : Object.keys(days).map(
-          (d) => daysOfWeekIndex[d] || [0, 0, 0, 0, 0, 0, 0]
-        );
+      : Object.keys(days).map(d => daysOfWeekIndex[d] || [0, 0, 0, 0, 0, 0, 0]);
   }
 
-  private getJourneyPatternIndex(
-    index: JourneyPatternIndex,
-    vehicle: any
-  ): JourneyPatternIndex {
+  private getJourneyPatternIndex(index: JourneyPatternIndex, vehicle: any): JourneyPatternIndex {
     if (vehicle.JourneyPatternRef) {
       index[vehicle.VehicleJourneyCode[0]] = vehicle.JourneyPatternRef[0];
     }
@@ -297,18 +215,18 @@ export class TransXChangeStream extends Transform {
  * TransXChange's comical idea of how to represent days of operation
  */
 export const daysOfWeekIndex: Record<string, DaysOfWeek> = {
-  MondayToFriday: [1, 1, 1, 1, 1, 0, 0],
-  MondayToSaturday: [1, 1, 1, 1, 1, 1, 0],
-  MondayToSunday: [1, 1, 1, 1, 1, 1, 1],
-  NotSaturday: [1, 1, 1, 1, 1, 0, 1],
-  Weekend: [0, 0, 0, 0, 0, 1, 1],
-  Monday: [1, 0, 0, 0, 0, 0, 0],
-  Tuesday: [0, 1, 0, 0, 0, 0, 0],
-  Wednesday: [0, 0, 1, 0, 0, 0, 0],
-  Thursday: [0, 0, 0, 1, 0, 0, 0],
-  Friday: [0, 0, 0, 0, 1, 0, 0],
-  Saturday: [0, 0, 0, 0, 0, 1, 0],
-  Sunday: [0, 0, 0, 0, 0, 0, 1],
+  "MondayToFriday": [1, 1, 1, 1, 1, 0, 0],
+  "MondayToSaturday": [1, 1, 1, 1, 1, 1, 0],
+  "MondayToSunday": [1, 1, 1, 1, 1, 1, 1],
+  "NotSaturday": [1, 1, 1, 1, 1, 0, 1],
+  "Weekend": [0, 0, 0, 0, 0, 1, 1],
+  "Monday": [1, 0, 0, 0, 0, 0, 0],
+  "Tuesday": [0, 1, 0, 0, 0, 0, 0],
+  "Wednesday": [0, 0, 1, 0, 0, 0, 0],
+  "Thursday": [0, 0, 0, 1, 0, 0, 0],
+  "Friday": [0, 0, 0, 0, 1, 0, 0],
+  "Saturday": [0, 0, 0, 0, 0, 1, 0],
+  "Sunday": [0, 0, 0, 0, 0, 0, 1],
 };
 
 /**

--- a/src/transxchange/TransXChangeStream.ts
+++ b/src/transxchange/TransXChangeStream.ts
@@ -104,7 +104,7 @@ export class TransXChangeStream extends Transform {
     index[operator.$.id] = {
       OperatorCode: operator?.OperatorCode?.[0] ? operator.OperatorCode[0] : operator?.NationalOperatorCode?.[0] ?? "",
       OperatorShortName: operator?.OperatorShortName?.[0] ?? "",
-      OperatorNameOnLicence: operator?.OperatorNameOnLicence?.[0] ? (operator.OperatorNameOnLicence[0]?._ ?? operator.OperatorNameOnLicence[0]) : "",
+      OperatorNameOnLicence: operator?.OperatorNameOnLicence?.[0] && (operator.OperatorNameOnLicence[0]?._ ?? operator.OperatorNameOnLicence[0] ?? ""),
     };
 
     return index;

--- a/src/transxchange/TransXChangeStream.ts
+++ b/src/transxchange/TransXChangeStream.ts
@@ -50,17 +50,17 @@ export class TransXChangeStream extends Transform {
 
     const result: TransXChange = {
       StopPoints: stops,
-      JourneySections: tx.JourneyPatternSections[0].JourneyPatternSection.reduce(
+      JourneySections: tx.JourneyPatternSections?.[0]?.JourneyPatternSection.reduce(
         this.getJourneySections,
         {}
       ),
-      Operators: (tx.Operators[0].Operator || [])
-        .concat(tx.Operators[0].LicensedOperator || [])
+      Operators: (tx.Operators?.[0]?.Operator || [])
+        .concat(tx.Operators?.[0]?.LicensedOperator || [])
         .reduce(this.getOperators, {}),
       Services: services,
-      VehicleJourneys: tx.VehicleJourneys[0].VehicleJourney.map((v: any) =>
-        this.getVehicleJourney(v, patternIndex, services)
-      ),
+      VehicleJourneys: (
+        tx.VehicleJourneys?.[0]?.VehicleJourney ?? []
+      ).map((v: any) => this.getVehicleJourney(v, patternIndex, services)),
     };
 
     callback(undefined, result);
@@ -68,8 +68,8 @@ export class TransXChangeStream extends Transform {
 
   private getStopFromAnnotatedStopPointRef(stop: any): StopPoint {
     return {
-      StopPointRef: stop.StopPointRef[0],
-      CommonName: stop.CommonName[0],
+      StopPointRef: stop.StopPointRef?.[0] ?? "",
+      CommonName: stop.CommonName?.[0] ?? "",
       LocalityName: stop.LocalityName?.[0] ? stop.LocalityName[0] : "",
       LocalityQualifier: stop.LocalityQualifier?.[0]
         ? stop.LocalityQualifier[0]
@@ -89,8 +89,8 @@ export class TransXChangeStream extends Transform {
 
   private getStopFromStopPoint(stop: any): StopPoint {
     return {
-      StopPointRef: stop.AtcoCode[0],
-      CommonName: stop.Descriptor[0].CommonName[0],
+      StopPointRef: stop.AtcoCode?.[0] ?? "",
+      CommonName: stop.Descriptor?.[0]?.CommonName?.[0],
       LocalityName: "",
       LocalityQualifier: "",
       Location: {
@@ -113,15 +113,15 @@ export class TransXChangeStream extends Transform {
 
   private getLink(l: any): TimingLink {
     return {
-      From: this.getJourneyStop(l.From[0]),
-      To: this.getJourneyStop(l.To[0]),
-      RunTime: Duration.parse(l.RunTime[0]),
+      From: this.getJourneyStop(l.From?.[0] ?? ""),
+      To: this.getJourneyStop(l.To?.[0] ?? ""),
+      RunTime: Duration.parse(l.RunTime?.[0] ?? ""),
     };
   }
 
   private getJourneyStop(stop: any): JourneyStop {
     return {
-      Activity: stop.Activity
+      Activity: stop.Activity?.[0]
         ? stop.Activity[0]
         : StopActivity.PickUpAndSetDown,
       StopPointRef: stop.StopPointRef?.[0] ?? "",
@@ -132,7 +132,7 @@ export class TransXChangeStream extends Transform {
 
   private getOperators(index: Operators, operator: any): Operators {
     index[operator.$.id] = {
-      OperatorCode: operator.OperatorCode
+      OperatorCode: operator.OperatorCode?.[0]
         ? operator.OperatorCode[0]
         : operator.NationalOperatorCode[0],
       OperatorShortName: operator.OperatorShortName[0],


### PR DESCRIPTION
**Description**

While attempting to process 19 April 2021 timetable data from `https://data.bus-data.dft.gov.uk/timetable/download/bulk_archive`, the library failed to process several fields, but I was unable to identify the file which was causing the failure when processing the entire archive as the error thrown was a typical uncaught error in a promise.

The cause of the error was caused by attempting to access certain indices that weren't present present - e.g. Line 128 in `TransXChangeStream.ts` trying to access `stop.TimingStatus[0]`, but that field or index not being present - essentially, either `timingStatus` or `timingStatus[0]` was not present.

**Solution implemented**

I have added optional chaining and nullish coalescing to several areas. Where appropriate, these fields will return an empty string in place so that the generated output is still valid. I have also updated some checks which were trying to return index 0 to first check if that index is actually available.

There may be other areas where this solution should be extended, but with the changes made here, I was able to successfully process the archive mentioned above.