### PR TITLE
Generate shapes.txt and other features and fixes

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -15,6 +15,7 @@ import { BankHolidays, TransXChangeJourneyStream } from "./transxchange/TransXCh
 import { CalendarDatesStream } from "./gtfs/CalendarDatesStream";
 import { TripsStream } from "./gtfs/TripsStream";
 import { StopTimesStream } from "./gtfs/StopTimesStream";
+import { ShapesStream } from "./gtfs/ShapesStream";
 import * as fs from "fs";
 import { TransfersStream } from "./gtfs/TransfersStream";
 import { GetStopData } from "./converter/GetStopData";
@@ -51,7 +52,8 @@ export class Container {
         "agency.txt": transxchange.pipe(new AgencyStream()),
         "routes.txt": transxchange.pipe(new RoutesStream()),
         "transfers.txt": transxchange.pipe(new TransfersStream(naptanIndex, locationIndex)),
-        "stops.txt": transxchange.pipe(new StopsStream(naptanIndex))
+        "stops.txt": transxchange.pipe(new StopsStream(naptanIndex)),
+        "shapes.txt": journeyStream.pipe(new ShapesStream())
       }
     );
   }

--- a/src/gtfs/AgencyStream.ts
+++ b/src/gtfs/AgencyStream.ts
@@ -12,14 +12,13 @@ export class AgencyStream extends GTFSFileStream<TransXChange> {
   private readonly agencyLang = process.env.AGENCY_LANG || "en";
 
   protected transform(data: TransXChange): void {
-    for (const operatorId of Object.keys(data.Operators)) {
-      if (!this.agenciesSeen[operatorId]) {
-        const operator = data.Operators[operatorId];
+    for (const operator of Object.values(data.Operators)) {
+      if (!this.agenciesSeen[operator.NationalOperatorCode]) {
         const agencyName = operator.TradingName || operator.OperatorNameOnLicence || operator.OperatorShortName;
 
-        this.pushLine(operatorId, agencyName, this.agencyUrl, this.agencyTimezone, this.agencyLang, "", "");
+        this.pushLine(operator.NationalOperatorCode, agencyName, this.agencyUrl, this.agencyTimezone, this.agencyLang, "", "");
 
-        this.agenciesSeen[operatorId] = true;
+        this.agenciesSeen[operator.NationalOperatorCode] = true;
       }
     }
   }

--- a/src/gtfs/GTFSFileStream.ts
+++ b/src/gtfs/GTFSFileStream.ts
@@ -41,7 +41,7 @@ export abstract class GTFSFileStream<T> extends Transform {
 
   private quote(value: string | number): string {
     return typeof value === "string"
-        ? value.includes(",") ? "\"" + value + "\"" : value
+        ? (value.includes(",") || value.includes("\"")) ? "\"" + value.replace(/"/g, "\"\"") + "\"" : value
         : value + "";
   }
 

--- a/src/gtfs/ShapesStream.ts
+++ b/src/gtfs/ShapesStream.ts
@@ -1,0 +1,88 @@
+import {GTFSFileStream} from "./GTFSFileStream";
+import {TransXChangeJourney} from "../transxchange/TransXChangeJourneyStream";
+import {createHash} from 'crypto';
+import {Location, RouteLink} from "../transxchange/TransXChange";
+
+// https://stackoverflow.com/questions/18883601/function-to-calculate-distance-between-two-coordinates
+function getDistanceFromLatLonInM(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  var R = 6371000; // Radius of the earth in km
+  var dLat = deg2rad(lat2-lat1);  // deg2rad below
+  var dLon = deg2rad(lon2-lon1); 
+  var a = 
+    Math.sin(dLat/2) * Math.sin(dLat/2) +
+    Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * 
+    Math.sin(dLon/2) * Math.sin(dLon/2)
+    ; 
+  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a)); 
+  var d = R * c; // Distance in km
+  return d;
+}
+
+function deg2rad(deg: number): number {
+  return deg * (Math.PI/180)
+}
+
+function routeLinkDistance(routeLink: RouteLink): number {
+  let distance = 0;
+  let lastLoc: Location | null = null;
+  for (const location of routeLink.Locations) {
+    if (lastLoc !== null) {
+      distance += getDistanceFromLatLonInM(lastLoc.Latitude, lastLoc.Longitude, location.Latitude, location.Longitude);
+    }
+    lastLoc = location;
+  }
+  return distance;
+}
+
+/**
+ * Generate shapes from the location data
+ */
+export class ShapesStream extends GTFSFileStream<TransXChangeJourney> {
+  protected header = "shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled";
+
+  protected existingShapes: Set<string> = new Set();
+
+  protected transform(journey: TransXChangeJourney): void {
+    let sequence = 0;
+    const shapeId = createHash('md5').update(JSON.stringify({ routeId: journey.route, routeLinkSeq: journey.routeLinkIds })).digest("hex");
+
+    if (this.existingShapes.has(shapeId)) {
+      return;
+    }
+    this.existingShapes.add(shapeId);
+
+    let lastLocAdded: Location | null = null;
+    let distanceSoFarM = 0;
+
+    for (const link of journey.routeLinks) {
+      // In the TXC file, the distance is provided only for every route link and not in each point within it
+      // For the GTFS file we need a distance for every point so we calculate this from the lat/long values
+      // However this is slightly inaccurate so we scale everything so the overall distance matches
+      const scaleFactor = link.Distance / routeLinkDistance(link);
+
+      let linkDistance = 0;
+      for (const location of link.Locations) {
+        if (
+          lastLocAdded !== null &&
+          lastLocAdded.Latitude === location.Latitude &&
+          lastLocAdded.Longitude === location.Longitude) {
+          continue;
+        }
+        linkDistance += lastLocAdded ? getDistanceFromLatLonInM(lastLocAdded.Latitude, lastLocAdded.Longitude, location.Latitude, location.Longitude) : 0;
+
+        this.pushLine(
+          shapeId,
+          location.Latitude,
+          location.Longitude,
+          sequence++,
+          ((distanceSoFarM + linkDistance * scaleFactor) / 1000).toFixed(5)
+        );
+
+        lastLocAdded = location;
+      }
+      distanceSoFarM += link.Distance;
+    }
+  }
+
+}
+

--- a/src/gtfs/StopTimesStream.ts
+++ b/src/gtfs/StopTimesStream.ts
@@ -8,7 +8,7 @@ export class StopTimesStream extends GTFSFileStream<TransXChangeJourney> {
   protected header = "trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled,timepoint";
 
   protected transform(journey: TransXChangeJourney): void {
-    let sequence = 1;
+    let sequence = 0;
 
     for (const stop of journey.stops) {
       this.pushLine(
@@ -17,7 +17,7 @@ export class StopTimesStream extends GTFSFileStream<TransXChangeJourney> {
         stop.departureTime,
         stop.stop,
         sequence++,
-        "",
+        stop.headsign ?? "",
         stop.pickup ? 0 : 1,
         stop.dropoff ? 0 : 1,
         stop.shapeDistTraveled,

--- a/src/gtfs/StopsStream.ts
+++ b/src/gtfs/StopsStream.ts
@@ -32,7 +32,7 @@ export class StopsStream extends GTFSFileStream<TransXChange> {
     return [
       atcoCode,
       naptanCode,
-      name + specificLocation + specificStreet + ", " + city,
+      name /*+ specificLocation + specificStreet + ", " + city*/,
       name,
       lat,
       lng,

--- a/src/gtfs/TripsStream.ts
+++ b/src/gtfs/TripsStream.ts
@@ -1,23 +1,25 @@
 import {GTFSFileStream} from "./GTFSFileStream";
 import {TransXChangeJourney} from "../transxchange/TransXChangeJourneyStream";
+import {createHash} from 'crypto';
 
 /**
  * Extract the trips from the TransXChange journeys
  */
 export class TripsStream extends GTFSFileStream<TransXChangeJourney> {
-  protected header = "route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,wheelchair_accessible,bikes_allowed,block_id";
+  protected header = "route_id,service_id,trip_id,trip_headsign,trip_short_name,direction_id,wheelchair_accessible,bikes_allowed,block_id,shape_id";
 
   protected transform(journey: TransXChangeJourney): void {
     this.pushLine(
       journey.route,
       journey.calendar.id,
       journey.trip.id,
-      "",
+      journey.trip.headsign,
       journey.trip.shortName,
       journey.trip.direction === "outbound" ? 0 : 1,
       0,
       0,
-      journey.blockId || ""
+      journey.blockId || "",
+      createHash('md5').update(JSON.stringify({ routeId: journey.route, routeLinkSeq: journey.routeLinkIds })).digest("hex")
     );
   }
 

--- a/src/transxchange/TransXChange.ts
+++ b/src/transxchange/TransXChange.ts
@@ -42,11 +42,13 @@ export interface StopPoint {
   StopPointRef: ATCOCode,
   CommonName: string,
   LocalityName: string,
-  LocalityQualifier: string
-  Location: {
-    Latitude: number,
-    Longitude: number
-  }
+  LocalityQualifier: string,
+  Location: Location
+}
+
+export interface Location {
+  Latitude: number,
+  Longitude: number
 }
 
 /**
@@ -55,7 +57,8 @@ export interface StopPoint {
 export interface RouteLink {
   From: ATCOCode,
   To: ATCOCode,
-  Distance: number
+  Distance: number,
+  Locations: Location[]
 }
 
 /**
@@ -64,8 +67,8 @@ export interface RouteLink {
 export interface JPTimingLink {
   From: JPJourneyStop,
   To: JPJourneyStop,
-  RunTime: Duration;
-  RouteLinkRef: string;
+  RunTime: Duration,
+  RouteLinkRef: string
 }
 
 /**
@@ -75,7 +78,7 @@ export interface VJTimingLink {
   JPTimingLinkRef: string, // Values inherited from JPTimingLink
   From?: VJJourneyStop,
   To?: VJJourneyStop,
-  RunTime?: Duration;
+  RunTime?: Duration
 }
 
 /**
@@ -86,6 +89,7 @@ export interface JPJourneyStop {
   StopPointRef: ATCOCode,
   TimingStatus: TimingStatus,
   WaitTime?: Duration,
+  DynamicDestinationDisplay?: string
 }
 
 export enum TimingStatus {
@@ -126,6 +130,7 @@ export type OperatorID = string;
  * Operator
  */
 export interface Operator {
+  NationalOperatorCode: string,
   OperatorCode: string,
   OperatorShortName: string,
   OperatorNameOnLicence: string | undefined,
@@ -169,6 +174,7 @@ export type JourneyPatterns = Record<JourneyPatternID, JourneyPattern>;
 export interface JourneyPattern {
   Direction: "inbound" | "outbound",
   Sections: JourneyPatternSectionID[],
+  DestinationDisplay?: string
 }
 
 /**
@@ -179,7 +185,15 @@ export type JourneyPatternID = string;
 /**
  * Lines indexed by line ID
  */
-export type Lines = Record<string, string>;
+export type Lines = Record<string, Line>;
+
+/**
+ * Line
+ */
+export interface Line {
+  LineName: string,
+  Description: string
+}
 
 /**
  * Period of operation


### PR DESCRIPTION
- Generate shapes.txt
- Use the National Operator Code as the main ID
- Fix issue with quotes in stop names
- Handle multiple routes defined in one service
- Include headsign in stop_times.txt
- Don't include street name and city in stop name
- Fix an issue when wait time was on the From rather than the To part of the link
- Other fixes that I forgot the purpose for
