### PR TITLE
Fix undefined route_type for rail mode and duplicate calendar_dates rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transxchange2gtfs",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Converts transxchange data to GTFS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/gtfs/CalendarDatesStream.ts
+++ b/src/gtfs/CalendarDatesStream.ts
@@ -7,6 +7,7 @@ import {LocalDate, DateTimeFormatter} from "js-joda";
  */
 export class CalendarDatesStream extends GTFSFileStream<TransXChangeJourney> {
   private readonly datesSeen: Record<string, boolean> = {};
+  private readonly dateRowsSeen: Set<string> = new Set();
   private readonly dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
   protected header = "service_id,date,exception_type";
@@ -22,7 +23,11 @@ export class CalendarDatesStream extends GTFSFileStream<TransXChangeJourney> {
 
   private pushDates(dates: LocalDate[], type: Day, serviceId: number): void {
     for (const date of dates) {
-      this.pushLine(serviceId, date.format(this.dateFormatter), type);
+      const key = `${serviceId}:${date.toString()}`;
+      if (!this.dateRowsSeen.has(key)) {
+        this.dateRowsSeen.add(key);
+        this.pushLine(serviceId, date.format(this.dateFormatter), type);
+      }
     }
   }
 

--- a/src/gtfs/RoutesStream.ts
+++ b/src/gtfs/RoutesStream.ts
@@ -8,11 +8,12 @@ export class RoutesStream extends GTFSFileStream<TransXChange> {
   protected header = "route_id,agency_id,route_short_name,route_long_name,route_type,route_text_color,route_color,route_url,route_desc";
 
   private routesSeen: Record<string, boolean> = {};
-  private routeType = {
+  private routeType: Record<Mode, number> = {
     [Mode.Air]: 1100,
     [Mode.Bus]: 3,
     [Mode.Coach]: 3,
     [Mode.Ferry]: 4,
+    [Mode.Rail]: 2,
     [Mode.Train]: 2,
     [Mode.Tram]: 0,
     [Mode.Underground]: 1

--- a/src/transxchange/TransXChange.ts
+++ b/src/transxchange/TransXChange.ts
@@ -198,6 +198,7 @@ export enum Mode {
   Coach = "coach",
   Underground = "underground",
   Ferry = "ferry",
+  Rail = "rail",
   Train = "train",
   Tram = "tram"
 }

--- a/test/gtfs/CalendarDatesStream.spec.ts
+++ b/test/gtfs/CalendarDatesStream.spec.ts
@@ -37,6 +37,31 @@ describe("CalendarDatesStream", () => {
     });
   });
 
+  it("deduplicates rows where the same date appears in both includes and excludes", async () => {
+    const stream = new CalendarDatesStream();
+
+    stream.write({
+      calendar: {
+        id: 1,
+        startDate: LocalDate.parse("2018-06-24"),
+        endDate: LocalDate.parse("2099-12-31"),
+        days: [1, 1, 1, 1, 1, 1, 1],
+        excludes: [LocalDate.parse("2018-12-25")],
+        includes: [LocalDate.parse("2018-12-25")]
+      }
+    });
+
+    stream.end();
+
+    return awaitStream(stream, (rows: string[]) => {
+      // header + 1 row only; the duplicate (service_id=1, date=20181225) must not be written twice
+      chai.expect(rows.length).to.equal(2);
+      const [service_id, date] = splitCSV(rows[1]);
+      chai.expect(service_id).to.equal("1");
+      chai.expect(date).to.equal("20181225");
+    });
+  });
+
   it("doesn't emit the same calendar twice", async () => {
     const stream = new CalendarStream();
 

--- a/test/gtfs/RoutesStream.spec.ts
+++ b/test/gtfs/RoutesStream.spec.ts
@@ -7,6 +7,35 @@ import {RoutesStream} from "../../src/gtfs/RoutesStream";
 
 describe("RoutesStream", () => {
 
+  it("emits rail routes with route_type 2", async () => {
+    const stream = new RoutesStream();
+
+    stream.write({
+      Services: {
+        "25-DLR-_-y05-216": {
+          "Description": "Bank - Beckton",
+          "Lines": { "l_DLR": "DLR" },
+          "Mode": "rail",
+          "OperatingPeriod": {
+            "EndDate": LocalDate.parse("2099-12-31"),
+            "StartDate": LocalDate.parse("2018-06-24")
+          },
+          "RegisteredOperatorRef": "OId_DLR",
+          "ServiceCode": "25-DLR-_-y05-216"
+        }
+      }
+    });
+
+    stream.end();
+
+    return awaitStream(stream, (rows: string[]) => {
+      const [route_id, , , , route_type] = splitCSV(rows[1]);
+
+      chai.expect(route_id).to.equal("25-DLR-_-y05-216");
+      chai.expect(route_type).to.equal("2");
+    });
+  });
+
   it("emits routes", async () => {
     const stream = new RoutesStream();
 


### PR DESCRIPTION
# Problem
Two bugs caused invalid GTFS output when converting TfL TransXChange data:

1. undefined route_type in routes.txt. TfL uses <Mode>rail</Mode> in their TransXChange files (DLR, Cable Car) but rail was absent from the Mode enum. The lookup this.routeType[service.Mode] returned undefined, which GTFS validators and consumers (e.g. r5py) reject — route_type must be an integer.

2. Duplicate (service_id, date) rows in calendar_dates.txt. When a date appeared in both a calendar's excludes and includes arrays (e.g. a bank holiday that also falls within a regular operating window), pushDates wrote it twice with different exception_type values. GTFS requires the (service_id, date) pair to be unique.

# Changes
- TransXChange.ts — add Rail = "rail" to the Mode enum
- RoutesStream.ts — map Mode.Rail to GTFS route type 2 (Rail); tighten the map type to Record<Mode, number> so the compiler catches any future missing entries
- CalendarDatesStream.ts — track written (serviceId, date) pairs in a Set inside pushDates and skip the second write if already seen