### PR TITLE
Add release workflow with version-gated npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20, 22]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check if package.json version is already published
+        id: check
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          echo "Checking $name@$version on npm..."
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version is already published; nothing to do."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$name@$version is new; will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.should_publish == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create git tag
+        if: steps.check.outputs.should_publish == 'true'
+        run: |
+          git tag "v${{ steps.check.outputs.version }}"
+          git push origin "v${{ steps.check.outputs.version }}"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` that runs on push to master:
1. **test** job: lint + tests on Node 20 and 22 (same matrix as CI)
2. **publish** job (needs: test): checks whether the version in `package.json` is already on the npm registry via `npm view`. If it's new, runs `npm publish` and tags `vX.Y.Z`. If the version hasn't been bumped, the job no-ops.

Workflow trigger model: bump the version in `package.json` in your PR — the merge to master publishes automatically. No tagging, no release notes, no separate step. Duplicate publishes are impossible because the version check runs before publish, and `npm publish` itself will reject a duplicate as a second line of defence.

`ci.yml` narrowed to `pull_request` only so master pushes don't double-run the same tests.

## Prerequisite

The repo needs an `NPM_TOKEN` secret set under Settings → Secrets and variables → Actions. Use an Automation token (bypasses 2FA) from https://www.npmjs.com/settings/{user}/tokens.

## Test plan

- [x] Both YAML files parse
- [ ] CI on this PR runs (should be green from the ci.yml narrowing; release.yml won't trigger yet since this is a PR not a master push)
- [ ] After merge: confirm release.yml runs on master. If the package.json version is unchanged (still 1.10.5, which is already on npm), the publish step will correctly skip
- [ ] Bump version in a follow-up PR and confirm publish + tag fires on merge