### PR TITLE
Tighten publish artifacts and fix prepublishOnly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   test:
@@ -47,6 +48,9 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -67,9 +71,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.should_publish == 'true'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
 
       - name: Create git tag
         if: steps.check.outputs.should_publish == 'true'

--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
   "bin": {
     "transxchange2gtfs": "bin/transxchange2gtfs.sh"
   },
+  "files": [
+    "dist",
+    "bin",
+    "README.md",
+    "logo.png"
+  ],
   "scripts": {
     "start": "tsx src/cli.ts",
-    "prepublishOnly": "rm -r dist;tsc -p ./ --outDir dist/; cp -r ./resource ./dist/",
+    "prepublishOnly": "rm -rf dist && tsc -p ./ --outDir dist/ && cp -r ./resource ./dist/",
     "test": "vitest run",
     "lint": "biome check src test",
     "lint:fix": "biome check --write src test",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
       "es2022"
     ]
   },
+  "include": ["src/**/*.ts"],
   "exclude": [
     "node_modules",
     "dist/"


### PR DESCRIPTION
Follow-up to the release workflow. The last publish attempt revealed that the tarball was shipping dev-only files (`.github/workflows/*`, `biome.json`, `vitest.config.ts` + its compiled `dist/vitest.config.*`, `tsconfig.json`, `.nvmrc`), and that \`prepublishOnly\` was printing a spurious \`rm: cannot remove 'dist': No such file or directory\` on clean CI checkouts.

## Changes

- **`package.json` `files` allow-list**: `dist`, `bin`, `README.md`, `logo.png`. This supersedes the deny-list in `.npmignore` and is authoritative about what ships.
- **`tsconfig.json` `include: ["src/**/*.ts"]`**: previously tsc picked up every root-level `.ts` file (including `vitest.config.ts`), which ended up in `dist/`. Now only `src/` compiles into `dist/`.
- **`prepublishOnly`**: `rm -r dist;tsc…;cp…` → `rm -rf dist && tsc… && cp…`. Tolerates a missing `dist`, and failures in any step now fail the script.

## Before / after tarball contents

Before (from failed run #24831308301): 11 files including `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.nvmrc`, `biome.json`, `dist/vitest.config.*`, `vitest.config.ts`.

After (local `npm pack --dry-run`): 44 files — only `dist/**` (incl. `resource/`), `bin/transxchange2gtfs.sh`, `README.md`, `logo.png`, `package.json`.

## Test plan

- [x] `npm test` — 42/42 passing
- [x] `npm run lint` — clean
- [x] `npm run prepublishOnly` runs clean with no error spam
- [x] `npm pack --dry-run` shows only allowed files

## Separate issue: token

The npm publish itself failed with a 404-on-PUT ("`transxchange2gtfs@1.10.5` is not in this registry"). That is npm's misleading way of saying the token can't publish. The `linusnorton` account is the registered maintainer, so the token likely needs to be an **Automation** token (not a classic "Publish" token, and not a read-only Granular token). Swap the `NPM_TOKEN` secret and re-run.