### PR TITLE
Fix publish npm upgrade + refresh README badges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
-
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ![transxchange2gtfs](logo.png)
 
-[![Travis](https://img.shields.io/travis/planarnetwork/transxchange2gtfs.svg?style=flat-square)](https://travis-ci.org/planarnetwork/transxchange2gtfs) ![npm](https://img.shields.io/npm/v/transxchange2gtfs.svg?style=flat-square) ![David](https://img.shields.io/david/planarnetwork/transxchange2gtfs.svg?style=flat-square)
+[![CI](https://img.shields.io/github/actions/workflow/status/planarnetwork/transxchange2gtfs/ci.yml?branch=master&style=flat-square&label=CI)](https://github.com/planarnetwork/transxchange2gtfs/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/transxchange2gtfs.svg?style=flat-square)](https://www.npmjs.com/package/transxchange2gtfs)
+[![npm downloads](https://img.shields.io/npm/dm/transxchange2gtfs.svg?style=flat-square)](https://www.npmjs.com/package/transxchange2gtfs)
+[![Node](https://img.shields.io/node/v/transxchange2gtfs.svg?style=flat-square)](https://nodejs.org)
+[![License](https://img.shields.io/npm/l/transxchange2gtfs.svg?style=flat-square)](https://www.gnu.org/licenses/gpl-3.0.html)
 
 transxchange2gtfs converts [TransXChange](http://naptan.dft.gov.uk/transxchange/index.htm) timetable data into a [GTFS](https://developers.google.com/transit/gtfs/) zip.
 


### PR DESCRIPTION
## Why

Two things:

1. **Last master build failed** at `Upgrade npm for trusted publishing` with \`Cannot find module 'promise-retry'\` ([run](https://github.com/planarnetwork/transxchange2gtfs/actions/runs/24850318110/job/72748726845)). Classic npm self-upgrade bug: \`npm install -g npm@latest\` replaces the npm binary mid-execution and the old process then can't find its now-swapped-out dependencies. Known issue, no clean workaround.

2. **README badges on master were dead**: Travis CI (project is on GitHub Actions) and David DM (service shut down in 2020).

## Changes

### `release.yml`
- Bump publish job to Node 24 (ships with npm 11.7+ which supports trusted publishing natively)
- Drop the `npm install -g npm@latest` step entirely

Tests still run on Node 20 + 22 as before — only the publish job moves to 24, because that's where we need the newer npm.

### `README.md`
Replaced the top-of-file badge row with five active badges:

```
[![CI](https://img.shields.io/github/actions/workflow/status/planarnetwork/transxchange2gtfs/ci.yml?branch=master&style=flat-square&label=CI)](...)
[![npm](https://img.shields.io/npm/v/transxchange2gtfs.svg?style=flat-square)](...)
[![npm downloads](https://img.shields.io/npm/dm/transxchange2gtfs.svg?style=flat-square)](...)
[![Node](https://img.shields.io/node/v/transxchange2gtfs.svg?style=flat-square)](...)
[![License](https://img.shields.io/npm/l/transxchange2gtfs.svg?style=flat-square)](...)
```

License badge links to the canonical GPL-3.0 text on gnu.org since there's no `LICENSE` file in the repo (license is only declared in `package.json`).

## Test plan

- [x] YAML parses
- [x] `npm test` and `npm run lint` still green locally
- [ ] On merge: Release workflow completes the publish step, publishes 1.10.5 with provenance, tags v1.10.5